### PR TITLE
Potential fix for code scanning alert no. 22: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -4660,6 +4660,19 @@ d-references {
   <h2>Table of contents</h2>
   <ul>`;
 
+    // Utility to escape HTML meta-characters in strings
+    function escapeHTML(str) {
+      return String(str).replace(/[&<>"']/g, function (c) {
+        return ({
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#39;'
+        })[c];
+      });
+    }
+
     for (const el of headings) {
       // should element be included in TOC?
       const isInTitle = el.parentElement.tagName == "D-TITLE";
@@ -4669,7 +4682,7 @@ d-references {
       const title = el.textContent;
       const link = "#" + el.getAttribute("id");
 
-      let newLine = "<li>" + '<a href="' + link + '">' + title + "</a>" + "</li>";
+      let newLine = "<li>" + '<a href="' + link + '">' + escapeHTML(title) + "</a>" + "</li>";
       if (el.tagName == "H3") {
         newLine = "<ul>" + newLine + "</ul>";
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/22](https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/22)

To fix the problem, we need to ensure that heading texts inserted into the table of contents are properly HTML-escaped before adding to the inner HTML. The best way is to encode all special HTML characters in the `title` string before constructing `newLine` with it. This prevents any `<`, `>`, `&`, `"` or `'` (and other) meta-characters from being interpreted as HTML/JavaScript, ensuring the TOC will display pure text. The correct place to change is where `title` is used in building the anchor tag; apply escaping to `title` before embedding it in the HTML string (`<a href="...">`).

This can be done by creating a reusable function to HTML-escape text and using it when constructing the TOC. The function can be placed above usages in the same file, and only `title` needs escaping (not `link`, as that is derived from `getAttribute("id")`; if `id` can be unsafe, similar escaping can also be applied).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
