### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -1,4 +1,6 @@
 name: Check for broken links
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/23](https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/23)

To fix the problem, you should explicitly set the minimal required GITHUB_TOKEN permissions for the workflow. As the workflow only checks out code and uses lychee to check links, the only needed permission is `contents: read`, which allows the workflow to access the code but not to make any modifications or write to artifacts, issues, or pull requests. You may choose to set the `permissions:` key at the top level of the workflow, which applies to all jobs (since there is only one job, this suffices). The change should be inserted after the workflow `name:` block and before the `on:` block, following YAML conventions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
