### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,4 +1,6 @@
 name: Prettier code formatter
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/21](https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/21)

To fix the problem, we need to explicitly set the job or workflow's `permissions` block to limit the GitHub token's capabilities. Since this workflow does not seem to need to modify repository contents, comment on PRs, or interact with privileged endpoints, the absolute minimal setting would be to set `permissions: contents: read` at the workflow root, ensuring the jobs do not have more permissions than necessary. This block should be inserted directly under the workflow `name` (line 1) so that it applies to all jobs, unless any individual job needs additional permissions (not the case here). No other changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
