### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prettier-html.yml
+++ b/.github/workflows/prettier-html.yml
@@ -1,4 +1,6 @@
 name: Prettify gh-pages
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/20](https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/20)

Add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to only the permissions required. Since this workflow checks out the `gh-pages` branch and pushes formatted files back, it requires `contents: write`. The best practice is to add `permissions: contents: write` at the root level of the workflow (line 2), which covers all jobs unless they override it.

**Steps needed:**
- At the top level of `.github/workflows/prettier-html.yml`, after the `name` key and before `on:`, add:
  ```yaml
  permissions:
    contents: write
  ```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
