### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prettier-comment-on-pr.yml
+++ b/.github/workflows/prettier-comment-on-pr.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [prettier-failed-on-pr]
 
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   comment:
     # available images: https://github.com/actions/runner-images#available-images


### PR DESCRIPTION
Potential fix for [https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/19](https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/19)

To fix this problem, the workflow should explicitly include a `permissions` block specifying the minimum required privileges for the job. For this workflow, which comments on a pull request (via `thollander/actions-comment-pull-request@v2`), it is sufficient to grant `pull-requests: write` and likely `contents: read` for read-only repository access. The preferred placement is at the root of the YAML file, so these permissions apply to all jobs unless further restricted, but it may also be added to the individual job. The fix consists of editing `.github/workflows/prettier-comment-on-pr.yml` to insert the following before the `jobs:` key:

```yaml
permissions:
  contents: read
  pull-requests: write
```

No imports or additional methods are needed.  
Edit lines prior to `jobs:` to add the block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
