### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lighthouse-badger.yml
+++ b/.github/workflows/lighthouse-badger.yml
@@ -7,6 +7,8 @@
 # Copyright (c) 2021 Sitdisch
 
 name: "Lighthouse Badger"
+permissions:
+  contents: read
 
 ########################################################################
 # DEFINE YOUR INPUTS AND TRIGGERS IN THE FOLLOWING


### PR DESCRIPTION
Potential fix for [https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/18](https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/18)

The fix is to explicitly add a `permissions` block to the workflow to control the permissions granted to the `GITHUB_TOKEN`.  
- The `permissions` block should be added at the top level (recommended) so that it applies globally to all jobs.  
- Based on the workflow's purpose (updating/generating badges and possibly updating content), you should grant only the minimum required permissions. If the workflow needs to push changes/badges, `contents: write` will typically be required; otherwise, if no write is necessary, the most restrictive setting would be `contents: read`.  
- As a minimal and safe starting point, set `permissions: contents: read` at the root level, and if pushing to the repo is indeed needed, consider raising to `contents: write` or adding job-specific permissions where needed.  
- To implement this, add the following at the top level, just after the `name` field (line 10):

```yaml
permissions:
  contents: read
```

(If later it is determined that write access is required, this can be bumped to `write`.) No new methods, imports, or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
