### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/axe.yml
+++ b/.github/workflows/axe.yml
@@ -1,5 +1,8 @@
 name: Axe accessibility testing
 
+permissions:
+  contents: read
+
 on:
   # if you want to run this on every push uncomment the following lines
   # push:


### PR DESCRIPTION
Potential fix for [https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/14](https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/14)

To fix this issue, we should add an explicit `permissions` block to the workflow, following the principle of least privilege. The safest approach is:
- Identify which permissions are actually required by the workflow (likely just `contents: read` for most CI workflows).
- Add the `permissions` block either at the workflow level (top of file, applies to all jobs unless overridden), or at the job level (inside the `check:` job block). Since this workflow only has one job, including it at the workflow level is recommended for clarity and extensibility.
- For this workflow, no job step is committing, writing, or creating issues/pull requests. Thus, `contents: read` is sufficient.

**Region to change:** Add the permissions block near the top, ideally after the workflow name.

**Needed:** No imports or new definitions, just the minimal YAML addition (`permissions: contents: read`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
