### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/broken-links-site.yml
+++ b/.github/workflows/broken-links-site.yml
@@ -1,4 +1,6 @@
 name: Check for broken links on site
+permissions:
+  contents: read
 
 on:
   workflow_run:


### PR DESCRIPTION
Potential fix for [https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/12](https://github.com/Dhruvacube/dhruvacube.github.io/security/code-scanning/12)

To resolve the problem, explicitly restrict the default permissions granted to the GitHub Actions `GITHUB_TOKEN`. The least privilege required for most workflows that only read the repository is `contents: read`. This should be set at the top of the workflow file, just below the workflow name, so it applies to all jobs within the workflow. No further code changes are needed elsewhere, as adding this block does not affect other workflow behavior.  
**How to fix:**  
- In `.github/workflows/broken-links-site.yml`, add the following YAML block after the `name:` field and before the `on:` field:

```yaml
permissions:
  contents: read
```

This sets the GITHUB_TOKEN to be read-only for repository contents by default for all jobs in the workflow, which is sufficient unless steps/jobs in the workflow require broader access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
